### PR TITLE
Remove slash after publicPath.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,10 @@ export default class WebappManifestPlugin {
     const config = this.config;
     return function hook(compilation) {
       compilation.plugin(HTML_PLUGIN_BEFORE_PROCESS, (htmlData, callback) => {
-        const publicPath = this.options.output.publicPath;
+        let publicPath = this.options.output.publicPath;
+        if (publicPath.length > 0 && publicPath[publicPath.length - 1] !== '/') {
+          publicPath += '/';
+        }
         htmlData.html = htmlData.html.replace('</head>', `  <link rel="manifest" href="${publicPath}manifest.json">\n</head>`);
         // we want to inject our manifest into the head
         callback(null, htmlData);

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ export default class WebappManifestPlugin {
     return function hook(compilation) {
       compilation.plugin(HTML_PLUGIN_BEFORE_PROCESS, (htmlData, callback) => {
         const publicPath = this.options.output.publicPath;
-        htmlData.html = htmlData.html.replace('</head>', `  <link rel="manifest" href="${publicPath}/manifest.json">\n</head>`);
+        htmlData.html = htmlData.html.replace('</head>', `  <link rel="manifest" href="${publicPath}manifest.json">\n</head>`);
         // we want to inject our manifest into the head
         callback(null, htmlData);
       });


### PR DESCRIPTION
This removes the slash between the `publicPath` and `manifest.json`.

This plugin is really awesome and we use it for almost all our webapps, but unfortunately it doesn't behave like all other plugins. If the `publicPath` is set to `/` (which it needs to be so that any other automatically generated link works), this slash causes the link to the manifest to start with `//`, causing the manifest file not to be found.