### PR TITLE
Add GitHub project links to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,14 @@
   "license": "MIT",
   "description": "Create a web application manifest for your PWA based on your webpack build.",
   "author": "David Buchan-Swanson <david.buchanswanson+npm@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/deecewan/webapp-manifest-plugin.git"
+  },
+  "bugs": {
+    "url": "https://github.com/deecewan/webapp-manifest-plugin/issues"
+  },
+  "homepage": "https://github.com/deecewan/webapp-manifest-plugin#readme",
   "devDependencies": {
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",


### PR DESCRIPTION
Whenever I look for the source of this great plugin, I fail to find it because it's not linked anywhere on the npm page and Google doesn't show the GitHub project to me :sweat_smile: 

This adds links to the npm project page, once you publish it with the updated package.json.